### PR TITLE
Archlinux hunspell-ko AUR 패키지 링크 및 설치 방법 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
    <http://packages.ubuntu.com/hunspell-ko>
  * 페도라/CentOS/RHEL: hunspell-ko 패키지 설치, 페도라 12 (Constantine) 이후,
    <https://apps.fedoraproject.org/packages/hunspell-ko/>
- * 아치리눅스: hunspell-ko AUR 패키지 설치
+ * 아치리눅스: hunspell-ko AUR 패키지 설치,
    <https://aur.archlinux.org/packages/hunspell-ko/>
    ```sh
    $ git clone ssh://aur@aur.archlinux.org/hunspell-ko.git

--- a/README.md
+++ b/README.md
@@ -28,6 +28,13 @@
    <http://packages.ubuntu.com/hunspell-ko>
  * 페도라/CentOS/RHEL: hunspell-ko 패키지 설치, 페도라 12 (Constantine) 이후,
    <https://apps.fedoraproject.org/packages/hunspell-ko/>
+ * 아치리눅스: hunspell-ko AUR 패키지 설치
+   <https://aur.archlinux.org/packages/hunspell-ko/>
+   ```sh
+   $ git clone ssh://aur@aur.archlinux.org/hunspell-ko.git
+   $ cd hunspell-ko
+   $ makepkg -sir
+   ```
  * Mac OS X 10.5: BaramSpellChecker
  * Mac OS X 10.6 이상: /Library/Spelling 또는 홈폴더/Library/Spelling
    아래 aff/dic 파일 복사


### PR DESCRIPTION
Archlinux 배포판에서 huspell-ko를 쉽게 이용할 수 있도록 AUR패키지를 만들었습니다.
패키지 링크와 함께 패키지 설치 방법도 올렸습니다.

AUR 패키지에 명시된 라이선스는 GPL3와 custom 라이선스로 본 레포의 LICENSE.md를 연결시켰습니다.
문제가 된다면 변경하겠습니다.